### PR TITLE
Simple Mapbox plugin

### DIFF
--- a/wp-content/plugins/mapbox-simple/README.md
+++ b/wp-content/plugins/mapbox-simple/README.md
@@ -1,0 +1,26 @@
+# mapbox-simple
+
+This Wordpress plugin provides integration Mapbox maps
+
+## Installation
+
+Install like any other Wordpress plugin
+
+## Configuration
+
+The plugin has a standard wordpress configuration panel, where you should input your MapBox API key.
+
+
+## Usage example:
+
+```
+[mapbox_map layers="gfdrr.map-wv1c9ry4,gfdrr.kathmandu-health" latitude="27.6934" longitude="85.3380" zoom="11" max_zoom="14"]
+```
+
+### Options + example values:
+- __layers__ (mandatory) comma separated list of layer ids to show
+- __latitude__ and __longitude__ (mandatory) (`27.6934`) coordinates of where to initially center the map
+- __zoom__ (`10`) default zoom level
+- __min_zoom__ (`10`) minimum zoom level
+- __max_zoom__ (`14`) maximum zoom level
+- __scroll_wheel_zoom__ (`false`) zooming in/out using mouse scroll is allowed

--- a/wp-content/plugins/mapbox-simple/mapbox-simple-settings.php
+++ b/wp-content/plugins/mapbox-simple/mapbox-simple-settings.php
@@ -1,0 +1,118 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class MapboxSimpleSettingsPage
+{
+  /**
+   * Holds the values to be used in the fields callbacks
+   */
+  private $mapbox_simple_apikey;
+
+  /**
+   * Start up
+   */
+  public function __construct()
+  {
+	add_action( 'admin_menu', array( $this, 'add_plugin_page' ) );
+	add_action( 'admin_init', array( $this, 'page_init' ) );
+  }
+
+  /**
+   * Add options page
+   */
+  public function add_plugin_page()
+  {
+	// This page will be under "Settings"
+	add_options_page(
+	  'Settings Admin',
+	  'Mapbox Simple',
+	  'manage_options',
+	  'mabox-simple-admin',
+	  array( $this, 'create_admin_page' )
+	);
+  }
+
+  /**
+   * Options page callback
+   */
+  public function create_admin_page()
+  {
+	// Set class property
+	$this->mapbox_simple_apikey = get_option( 'mapbox_simple_apikey', 'SET UP MAPBOX API KEY' );
+	?>
+	<div class="wrap">
+	  <h1>Mapbox Simple Settings</h1>
+	  <form method="post" action="options.php">
+		<?php
+		// This prints out all hidden setting fields
+		settings_fields( 'mapbox_simple_group' );
+		do_settings_sections( 'mapbox-simple-admin' );
+		submit_button();
+		?>
+	  </form>
+	</div>
+	<?php
+  }
+
+  /**
+   * Register and add settings
+   */
+  public function page_init()
+  {
+	register_setting(
+	  'mapbox_simple_group', // Option group
+	  'mapbox_simple_apikey', // Option name
+	  array( $this, 'sanitize' ) // Sanitize
+	);
+
+	add_settings_section(
+	  'mapbox_simple', // ID
+	  'Mapbox Simple', // Title
+	  null, // Callback
+	  'mapbox-simple-admin' // Page
+	);
+
+	add_settings_field(
+	  'mapbox_simple_apikey', // ID
+	  'API Key', // Title
+	  array( $this, 'mapbox_simple_apikey_callback' ),
+	  'mapbox-simple-admin', // Page
+	  'mapbox_simple' // Section
+	);
+
+  }
+
+  /**
+   * Sanitize each setting field as needed
+   *
+   * @param array $input Contains all settings fields as array keys
+   *
+   * @return array
+   */
+  public function sanitize( $input )
+  {
+	$new_input = array();
+
+	if ( isset( $input ) ) {
+	  $new_input = sanitize_text_field( $input );
+	}
+
+	return $new_input;
+  }
+
+  /**
+   * Get the settings option array and print one of its values
+   */
+  public function mapbox_simple_apikey_callback()
+  {
+	printf(
+	  '<input type="text" id="endpoint" name="mapbox_simple_apikey" value="%s" />',
+	  isset( $this->mapbox_simple_apikey ) ? esc_attr( $this->mapbox_simple_apikey) : ''
+	);
+  }
+}
+
+if ( is_admin() ) {
+  $mapbox_simple_settings_page = new MapboxSimpleSettingsPage();
+}

--- a/wp-content/plugins/mapbox-simple/mapbox-simple.php
+++ b/wp-content/plugins/mapbox-simple/mapbox-simple.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Plugin Name: mapbox-simple
+ * Description: Allows adding a configurable mapbox map to a post
+ * Author: Vizzuality
+ * Author URI: http://vizzuality.com
+ */
+require_once __DIR__ . '/mapbox-simple-settings.php';
+$MAPBOX_SIMPLE_APIKEY = get_option('mapbox_simple_apikey' );
+
+
+function mapbox_map( $atts ) {
+  global $MAPBOX_SIMPLE_APIKEY;
+  $atts_encode = json_encode($atts);
+  // $test_param = getVal($atts, '$test_param', 'thi is a test');
+  $map_id = uniqid('mapbox-simple-');
+  return <<<EOD
+  {$MAPBOX_SIMPLE_APIKEY}
+  <div id='{$map_id}' style='width:100%; height: 400px'></div>
+  <script>
+    console.log({$atts_encode})
+    L.mapbox.accessToken = '{$MAPBOX_SIMPLE_APIKEY}';
+
+    try {
+      var map = L.mapbox.map('{$map_id}', 'gfdrr.map-wv1c9ry4,gfdrr.kathmandu-health')
+      .setView([27.6934,85.3380], 15);
+    } catch (e) {
+      console.log(e)
+    }
+  </script>
+EOD;
+}
+
+// example: []
+add_shortcode( 'mapbox_map', 'mapbox_map' );
+
+function mapbox_simple_scripts() {
+   wp_register_script('mapbox_simple_js', 'https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.js' );
+   wp_enqueue_script('mapbox_simple_js');
+   wp_register_style('mapbox_simple_styles', 'https://api.mapbox.com/mapbox.js/v3.1.1/mapbox.css' );
+   wp_enqueue_style('mapbox_simple_styles');
+}
+
+add_action( 'wp_enqueue_scripts', 'mapbox_simple_scripts' );
+
+?>

--- a/wp-content/plugins/mapbox-simple/mapbox-simple.php
+++ b/wp-content/plugins/mapbox-simple/mapbox-simple.php
@@ -8,30 +8,36 @@
 require_once __DIR__ . '/mapbox-simple-settings.php';
 $MAPBOX_SIMPLE_APIKEY = get_option('mapbox_simple_apikey' );
 
+function getMapboxSimpleVal($params, $value, $default) {
+  return isset($params[$value]) ? $params[$value] : $default;
+}
 
 function mapbox_map( $atts ) {
   global $MAPBOX_SIMPLE_APIKEY;
-  $atts_encode = json_encode($atts);
-  // $test_param = getVal($atts, '$test_param', 'thi is a test');
   $map_id = uniqid('mapbox-simple-');
+  $layers = getMapboxSimpleVal($atts, 'layers', 'mapbox.streets');
+  $latitude = getMapboxSimpleVal($atts, 'latitude', '40.4746');
+  $longitude = getMapboxSimpleVal($atts, 'longitude', '-3.7048');
+  $zoom = getMapboxSimpleVal($atts, 'zoom', '3');
+  $minZoom = getMapboxSimpleVal($atts, 'min_zoom', '0');
+  $maxZoom = getMapboxSimpleVal($atts, 'max_zoom', '22');
+  $scrollWheelZoom = getMapboxSimpleVal($atts, 'scroll_wheel_zoom', 'false');
   return <<<EOD
-  {$MAPBOX_SIMPLE_APIKEY}
   <div id='{$map_id}' style='width:100%; height: 400px'></div>
   <script>
-    console.log({$atts_encode})
     L.mapbox.accessToken = '{$MAPBOX_SIMPLE_APIKEY}';
 
-    try {
-      var map = L.mapbox.map('{$map_id}', 'gfdrr.map-wv1c9ry4,gfdrr.kathmandu-health')
-      .setView([27.6934,85.3380], 15);
-    } catch (e) {
-      console.log(e)
-    }
+    var map = L.mapbox.map('{$map_id}', '{$layers}', {
+        minZoom: {$minZoom},
+        maxZoom: {$maxZoom},
+        scrollWheelZoom: {$scrollWheelZoom}
+      })
+      .setView([{$latitude}, {$longitude}], {$zoom});
   </script>
 EOD;
 }
 
-// example: []
+// example: [mapbox_map layers="gfdrr.map-wv1c9ry4,gfdrr.kathmandu-health" latitude="27.6934" longitude="85.3380" zoom="14" max_zoom="20"]
 add_shortcode( 'mapbox_map', 'mapbox_map' );
 
 function mapbox_simple_scripts() {


### PR DESCRIPTION
Adds a WP plugin wrapper for Mapbox.js (Mapbox Leaflet wrapper), called 'Mapbox Simple'
https://www.mapbox.com/mapbox.js/api/v3.1.1

![screen shot 2017-09-28 at 15 43 50](https://user-images.githubusercontent.com/1583415/30970005-560adb18-a464-11e7-83e7-f5050f59bc2f.png)

First, set api key in wp admin (Settings -> Mapbox Simple). 

TODO:
- [ ] fix CSS visual conflict in zoom controls
- [ ] configurable width/height
- [ ] move to own repo
- [x] shortcode documentation
Example: `[mapbox_map layers="gfdrr.map-wv1c9ry4,gfdrr.kathmandu-health" latitude="27.6934" longitude="85.3380" zoom="14" max_zoom="20"]`
- [ ] test with other maps
- [ ] (if needed) add more shortcode params, see https://www.mapbox.com/mapbox.js/api/v3.1.1/l-map-class/
- [ ] (probably not) switch from mapbox.js (deprecated) to Mapbox GL JS